### PR TITLE
Updated copyright footer to be in the middle of page

### DIFF
--- a/about.html
+++ b/about.html
@@ -114,6 +114,6 @@
 </ul>
 </div>
 </footer>
-<p>csit 'c'..&copy; All rights reserved.</p>
+<p class="copyright-footer" >The Sristy-Club &copy; 2019 All rights reserved.</p>
 </body>
 </html>

--- a/ht.css
+++ b/ht.css
@@ -38,6 +38,12 @@ html,body{
 	border-bottom: 1px solid rgba(255,255,255,.3);
 }
 
+.copyright-footer{
+	position: absolute;
+	left: 50%;
+	transform: translateX(-50%);
+}
+
 .main-nav li{
 	padding: 0 5%;
 

--- a/ht.html
+++ b/ht.html
@@ -87,7 +87,7 @@
 
 </ul>
 </div>
-<p>csit 'c'..&copy; All rights reserved.</p>
+<p class="copyright-footer" >The Sristy-Club &copy; 2019 All rights reserved.</p>
 </footer>
 
 </body>

--- a/nr.html
+++ b/nr.html
@@ -134,7 +134,7 @@
 
 </ul>
 </div>
-<p>csit 'c'..&copy; All rights reserved.</p>
+<p class="copyright-footer" >The Sristy-Club &copy; 2019 All rights reserved.</p>
 </footer>
 
 


### PR DESCRIPTION
I updated to copyright footer and added CSS so the footer will be in the **middle of the page**. 

**This is the changed HTML copyright footer**
`<p class="copyright-footer" >The Sristy-Club &copy; 2019 All rights reserved.</p>`

**This is the added CSS** 
`.copyright-footer{
	position: absolute;
	left: 50%;
	transform: translateX(-50%);
}`
